### PR TITLE
Headers parsing fix + proper x-amz-date header handling

### DIFF
--- a/s3curl.pl
+++ b/s3curl.pl
@@ -235,7 +235,8 @@ foreach (sort (keys %xamzHeaders)) {
     $xamzHeadersToSign .= "$_:$headerValue\n";
 }
 
-my $httpDate = POSIX::strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime );
+# NOTE: Need to skip the Date: header, in case x-amz-date got provided
+my $httpDate = (defined $xamzHeaders{'x-amz-date'}) ? '' : POSIX::strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime);
 my $stringToSign = "$method\n$contentMD5\n$contentType\n$httpDate\n$xamzHeadersToSign$resource";
 
 debug("StringToSign='" . $stringToSign . "'");
@@ -245,7 +246,8 @@ my $signature = encode_base64($hmac->digest, "");
 
 
 my @args = ();
-push @args, ("-H", "Date: $httpDate");
+push @args, ("-v") if ($debug);
+push @args, ("-H", "Date: $httpDate") if ($httpDate);
 push @args, ("-H", "Authorization: AWS $keyId:$signature");
 push @args, ("-H", "x-amz-acl: $acl") if (defined $acl);
 push @args, ("-L");

--- a/s3curl.pl
+++ b/s3curl.pl
@@ -214,7 +214,7 @@ for (my $i=0; $i<@ARGV; $i++) {
         if ($header =~ /^[Hh][Oo][Ss][Tt]:(.+)$/) {
             $host = $1;
         }
-        elsif ($header =~ /^([Xx]-[Aa][Mm][Zz]-.+): *(.+)$/) {
+        elsif ($header =~ /^([Xx]-[Aa][Mm][Zz]-[^:]+): *(.+)$/) {
             my $name = lc $1;
             my $value = $2;
             # merge with existing values
@@ -275,7 +275,7 @@ if (defined $createBucket) {
 
 push @args, @ARGV;
 
-debug("exec $CURL " . join (" ", @args));
+debug("exec $CURL " . join (" ", map { / / && qq/'$_'/ || $_ } @args));
 exec($CURL, @args)  or die "can't exec program: $!";
 
 sub debug {


### PR DESCRIPTION
The s3curl was parsing headers incorrectly, so the header-values were
converted to lowercase before sending for HMAC-signature calculation.

After the fix, the following examples work correctly (please adjust buckets/keys):
    s3curl.pl --id=xx --copySrc /yy/zz -- http://bucket.s3.amazonaws.com/newKey \
	-H "x-amz-copy-source-if-modified-since: Tue, 20 May 2014 07:50:15 -0700" -v
    s3curl.pl --id=xx --createBucket -- http://bucket.s3.amazonaws.com \
	-H "x-amz-grant-full-control: uri=http://acs.amazonaws.com/groups/global/AllUsers" -v

Also fixed the debug-message with the curl-invocation, so that the
parameters are quoted if necessary.