### PR TITLE
Removing 5 second sleep

### DIFF
--- a/s3curl.pl
+++ b/s3curl.pl
@@ -123,7 +123,6 @@ die $usage if $help || !defined $keyId;
 
 if ($cmdLineSecretKey) {
     printCmdlineSecretWarning();
-    sleep 5;
 
     $secretKey = $cmdLineSecretKey;
 } else {
@@ -332,7 +331,7 @@ For example:
 
 \$ chmod 600 $DOTFILE
 
-Will sleep and continue despite this problem.
+Will continue despite this problem.
 Please set up $DOTFILE for future requests.
 END_WARNING
 }


### PR DESCRIPTION
The 5 second sleep is unnecessary, and the fact that it cannot be by-passed makes it problematic for some scripting tasks. This addresses issue 18.